### PR TITLE
Keeps class attribute on SVG elements

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,12 +63,18 @@ var transform = function (filename) {
             output = babel.transform(source, settings.babel);
 
         var replaceAttribute = function (a, str) {
-          return str.replace(/-(.)/g, function (_, letter) {
-            return letter.toUpperCase();
-          });
+          switch (str) {
+            case 'class':
+              return 'className';
+
+            default:
+              return str.replace(/-(.)/g, function (_, letter) {
+                return letter.toUpperCase();
+              });
+          }
         };
 
-        output.code = output.code.replace(/\"(clip-path|fill-opacity|font-family|font-size|marker-end|marker-mid|marker-start|stop-color|stop-opacity|stroke-width|stroke-linecap|stroke-dasharray|stroke-opacity|text-anchor)\"/g, replaceAttribute);
+        output.code = output.code.replace(/\"(class|clip-path|fill-opacity|font-family|font-size|marker-end|marker-mid|marker-start|stop-color|stop-opacity|stroke-width|stroke-linecap|stroke-dasharray|stroke-opacity|text-anchor)\"/g, replaceAttribute);
 
         stream.queue(output.code);
         stream.queue(null);

--- a/test/main.js
+++ b/test/main.js
@@ -176,4 +176,19 @@ describe('The app', function () {
     }, {
         template: 'all'
     }));
+
+    it('should work for all template and keep class attribute intact via props', load('some.svg', function (svg) {
+
+        var component = React.createElement(svg, {
+                type: 'svg'
+            }),
+            rendered  = TestUtils.renderIntoDocument(component),
+            path      = TestUtils.findRenderedDOMComponentWithTag(rendered, 'path');
+
+        (rendered.getDOMNode().tagName.toLowerCase()).should.equal('svg');
+        (rendered.getDOMNode().querySelector('path').getAttribute('d')).should.equal('M0 0h100v100H0z');
+        (rendered.getDOMNode().querySelector('path').getAttribute('class')).should.equal('someclass');
+    }, {
+        template: 'all'
+    }));
 });

--- a/test/svg/some.svg
+++ b/test/svg/some.svg
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
-    <path d="M0 0h100v100H0z" stroke-width="2.5" clip-path="something" />
+    <path d="M0 0h100v100H0z" stroke-width="2.5" clip-path="something" class="someclass" />
 </svg>


### PR DESCRIPTION
This replaces the string "class" with "className", so that class attributes used in an SVG file is correctly transformed as prop to the corresponding React element
