### PR TITLE
Address deprecation of `React.createClass`

### DIFF
--- a/src/template/icon.js
+++ b/src/template/icon.js
@@ -1,15 +1,13 @@
 export default (name, svg) => `var React = require('react'), SVG = ${ svg }
 
-module.exports = React.createClass({
-    displayName: 'svg-${ name }',
-    getDefaultProps: function () {
+function SVGComponent (props) {
 
-        return {
-            className: 'icon icon-${ name }'
-        };
-    },
-    render: function () {
+    return React.createElement('span', props, SVG);
+};
 
-        return React.createElement('span', this.props, SVG);
-    }
-});`;
+SVGComponent.displayName = 'svg-${ name }',
+SVGComponent.defaultProps = {
+    className: 'icon icon-${ name }'
+}
+
+module.exports = SVGComponent;`

--- a/src/template/image.js
+++ b/src/template/image.js
@@ -1,9 +1,10 @@
 export default (name, svg) => `var React = require('react'), SVG = ${ svg }
 
-module.exports = React.createClass({
-    displayName: 'svg-${ name }',
-    render     : function () {
+function SVGComponent(props) {
 
-        return SVG;
-    }
-});`;
+    return SVG;
+}
+
+SVGComponent.displayName = 'svg-${ name }';
+
+module.exports = SVGComponent`;


### PR DESCRIPTION
## Problem
The current templates relay on `React.createClass` which is deprecated starting in React 15.

## Solution
The template should assume as little as possible about the user's browserify setup. The output has to be valid ES5 because we can't rely on JSX or ES6 support coming after in the transformation pipeline.

[Functional components](https://reactjs.org/docs/components-and-props.html#functional-and-class-components) are just functions with some properties set, so I think they are adequate.

Support for functional components was added in React v0.14, released three years ago. Nonetheless, this would be a backwards-incompatible change so you should probably bump the version number if you merge this PR.

## Tests
- Tests pass.
- The warning is gone in React 15.
- The sample app (using React 0.14) still works fine.